### PR TITLE
Dockerignore and venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ My cookiecutter template for flask APIs
     - ```$ cookiecutter https://github.com/bnbalsamo/cookiecutter-flask_api_template```
     - Fill in the prompts
     - ```$ cd $YOUR_PROJECT_NAME```
-    - ```$ source .env/bin/activate```
+    - ```$ source venv/bin/activate```
         - if python < 3.3 create your own venv here
     - ```$ pip install -r requirements_dev.txt```
     - ```$ git init```

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -13,7 +13,7 @@ def make_venv():
     from venv import main
 
     cookiecutter_args = "{{cookiecutter.venv_args}}"
-    args = "{}".format(join(getcwd(), '.env'))
+    args = "{}".format(join(getcwd(), 'venv'))
     if cookiecutter_args != "":
         args = "{} {}".format(cookiecutter_args, args)
     main(args.split())

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -19,7 +19,7 @@ def make_venv():
     main(args.split())
     print("Virtual environment successfully created. Activate " +
           "it with: \n" +
-          "$ source .env/bin/activate \n" +
+          "$ source venv/bin/activate \n" +
           "from the project root\n")
 
 

--- a/{{ cookiecutter.project_name }}/.dockerignore
+++ b/{{ cookiecutter.project_name }}/.dockerignore
@@ -1,0 +1,43 @@
+# The usual suspects
+.git
+.gitignore
+.travis.yml
+venv
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Flask stuff:
+instance/
+.webassets-cache

--- a/{{ cookiecutter.project_name }}/setup.cfg
+++ b/{{ cookiecutter.project_name }}/setup.cfg
@@ -8,13 +8,13 @@ in-place = True
 recursive = True
 max-line-length = {{ cookiecutter.max_line_length }}
 verbose = 1
-exclude = .env, build, dist, .git, __pycache__
+exclude = venv, build, dist, .git, __pycache__
 
 # flake8 config
 [flake8]
 max-line-length = {{ cookiecutter.max_line_length }}
 ignore = E121,E123,E126,E226,E24,E402,E704,W503,W504
-exclude = .env, build, dist, .git, __pycache__
+exclude = venv, build, dist, .git, __pycache__
 
 # bumpversion config
 [bumpversion]


### PR DESCRIPTION
Adds a .dockerignore to produced cookies. Also changes the default venv to a dir named "venv" instead of ".env" to avoid conflicts with .env files.