### PR TITLE
blueprint error handlers can't handle 500 errors, which is what flask…

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.0
+current_version = 0.5.1
 commit = True
 tag = True
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cookiecutter-flask_api_template
 
-v0.5.0
+v0.5.1
 
 [![Build Status](https://travis-ci.org/bnbalsamo/cookiecutter-flask_api_template.svg?branch=master)](https://travis-ci.org/bnbalsamo/cookiecutter-flask_api_template)
 

--- a/{{ cookiecutter.project_name }}/{{ cookiecutter.slug_name }}/__init__.py
+++ b/{{ cookiecutter.project_name }}/{{ cookiecutter.slug_name }}/__init__.py
@@ -1,5 +1,6 @@
-from flask import Flask
+from flask import Flask, jsonify
 from .blueprint import BLUEPRINT, __version__, __email__, __author__
+from .blueprint.exceptions import Error
 from flask_env import MetaFlaskEnv
 
 
@@ -10,6 +11,14 @@ class Configuration(metaclass=MetaFlaskEnv):
 
 
 app = Flask(__name__)
+
+
+@app.errorhandler(Error)
+def handle_errors(error):
+    response = jsonify(error.to_dict())
+    response.status_code = error.status_code
+    return response
+
 
 app.config.from_object(Configuration)
 

--- a/{{ cookiecutter.project_name }}/{{ cookiecutter.slug_name }}/blueprint/__init__.py
+++ b/{{ cookiecutter.project_name }}/{{ cookiecutter.slug_name }}/blueprint/__init__.py
@@ -3,10 +3,9 @@
 """
 import logging
 
-from flask import Blueprint, jsonify
+from flask import Blueprint
 from flask_restful import Resource, Api
 
-from .exceptions import Error
 
 __author__ = "{{ cookiecutter.author }}"
 __email__ = "{{ cookiecutter.email }}"
@@ -20,13 +19,6 @@ BLUEPRINT.config = {}
 API = Api(BLUEPRINT)
 
 log = logging.getLogger(__name__)
-
-
-@BLUEPRINT.errorhandler(Error)
-def handle_errors(error):
-    response = jsonify(error.to_dict())
-    response.status_code = error.status_code
-    return response
 
 
 class Root(Resource):

--- a/{{ cookiecutter.project_name }}/{{ cookiecutter.slug_name }}/blueprint/exceptions.py
+++ b/{{ cookiecutter.project_name }}/{{ cookiecutter.slug_name }}/blueprint/exceptions.py
@@ -10,3 +10,10 @@ class Error(Exception):
     def to_dict(self):
         return {"message": self.message,
                 "error_name": self.err_name}
+
+
+# Exceptions which inherit from Error go here.
+# Note that they will only be handled correctly if
+# the included app errorhandler is used, or if whatever
+# application mounts the blueprint implements a similar
+# error handler.


### PR DESCRIPTION
… throws if an exception is raised. Thus, the error handler has to be defined on the application, rather than the blueprint. See: https://github.com/pallets/flask/blob/8020d5eac9e4bb0e40a47b82ca95713ee78fc73c/flask/blueprints.py#L418